### PR TITLE
Fix amend

### DIFF
--- a/packages-available/50-Did/amendDid.achel
+++ b/packages-available/50-Did/amendDid.achel
@@ -1,4 +1,4 @@
-# Amend the details of something you've done. --amendDid=[taskName],[who],[comment] ~ doneit,user
+# Amend the details of something you've done. --amendDid=[taskName],[who],[comment],[contextSearch] ~ doneit,user
 #onDefine aliasFeature amendDid,amend
 
 parameters taskName,who,comment,contextSearch

--- a/packages-available/50-Did/amendDid.achel
+++ b/packages-available/50-Did/amendDid.achel
@@ -44,6 +44,19 @@ loop
 			set Result,id,~!Local,ID!~
 			debug 2,amendDid: Setting context ~!Me,context!~ from search ~!Local,contextSearch!~
 			setNested DoneIt,dids,~!Result,id!~,context,~!Me,context!~
+		else
+			stashResults Local,beforeContext
+			isolate
+				listTasks ^~!DoneIt,dids,~!Result,id!~,taskName!~$
+				first
+				loop Task,
+					if ~!Task,context!~,==,personal,
+						setNested DoneIt,dids,~!Result,id!~,context,personal
+					else
+						set Me,context,
+						getContext Me,context
+						setNested DoneIt,dids,~!Result,id!~,context,~!Me,context!~
+			retrieveResults Local,beforeContext
 
 		# Display after
 		isolate


### PR DESCRIPTION
Before, `--amend` would correctly set everything else, but the context would not change in the expected way based on which task is going in place of the old one.

This PR fixes that.
