### PR TITLE
Add hours day/week

### DIFF
--- a/packages-available/50-Did/hoursPerDay.achel
+++ b/packages-available/50-Did/hoursPerDay.achel
@@ -1,0 +1,58 @@
+# For a list of dids (eg --today), list the number of hours worked each day. ~ did,summary,hours,day
+#onDefine aliasFeature hoursPerDay,hpd
+
+countToVar Local,dids
+if ~!Local,dids!~,==,0,
+    today
+    requireContext
+
+# Collect hours into days.
+set Local,collectedHours
+loop
+    fullTimeStamp Local,date,~!Result,start!~,Y-m-d
+    if ~!Local,collectedHours,~!Local,date!~,duration!~,==,,
+        setNested Local,collectedHours,~!Local,date!~,duration,0
+    set Local,currentTotal,~!Local,collectedHours,~!Local,date!~,duration!~
+
+    basicMaths Local,currentTotal,~!Local,currentTotal!~,+,~!Result,duration!~
+    setNested Local,collectedHours,~!Local,date!~,duration,~!Local,currentTotal!~
+
+retrieveResults Local,collectedHours
+
+# Perform statistics.
+basicMaths Local,dividor,60,*,60
+# TODO Make the goal configurable.
+basicMaths Local,goal,~!DoneIt,hoursPerDay!~,*,~!Local,dividor!~
+set HoursPerDay,totalWorked,0
+set Local,totalRemaining,0
+set Local,daysWorked,0
+
+loop
+    basicMaths Result,remaining,~!Local,goal!~,-,~!Result,duration!~
+
+    fuzzyTime Result,fuzzyDuration,~!Result,duration!~
+    fuzzyTime Result,fuzzyRemaining,~!Result,remaining!~
+
+    now Local,now
+    basicMaths Result,finishTime,~!Local,now!~,+,~!Result,remaining!~
+    fuzzyTime Result,fuzzyFinishTime,~!Result,finishTime!~
+
+    basicMaths HoursPerDay,daysWorked,~!HoursPerDay,daysWorked!~,+,1
+    basicMaths Local,totalWorked,~!Local,totalWorked!~,+,~!Result,duration!~
+    basicMaths Local,totalRemaining,~!Local,totalRemaining!~,+,~!Result,remaining!~
+
+fuzzyTime HoursPerDay,fuzzyTotalWorked,~!Local,totalWorked!~,hours
+fuzzyTime HoursPerDay,fuzzyTotalRemaining,~!Local,totalRemaining!~,hours
+
+basicMaths HoursPerDay,hoursPerWeek,~!DoneIt,hoursPerDay!~,*,~!DoneIt,daysPerWeek!~
+basicMaths Local,secondsPerWeek,~!HoursPerDay,hoursPerWeek!~,*,~!Local,dividor!~
+basicMaths Local,weekSecondsRemaining,~!Local,secondsPerWeek!~,-,~!Local,totalWorked!~
+fuzzyTime HoursPerDay,fuzzyWeekTotalRemaining,~!Local,weekSecondsRemaining!~,hours
+
+countToVar Local,days
+if ~!Local,days!~,>,1,
+    set HoursPerDay,unit,days
+else
+    set HoursPerDay,unit,day
+
+templateOut hoursPerDay

--- a/packages-available/50-Did/hoursPerDay.template
+++ b/packages-available/50-Did/hoursPerDay.template
@@ -1,0 +1,7 @@
+<~~ ~!Color,default!~~%key%~: ~!Color,green!~~%fuzzyDuration%~~!Color,brightBlack!~, ~!Color,cyan!~~%fuzzyRemaining%~ remaining~!Color,brightBlack!~. Finishing at ~!Color,purple!~~%fuzzyFinishTime%~~!Color,brightBlack!~.
+
+~>
+~!Color,default!~~!HoursPerDay,daysWorked!~ ~!HoursPerDay,unit!~ worked:~!Color,green!~ ~!HoursPerDay,fuzzyTotalWorked!~~!Color,brightBlack!~,
+    * ~!Color,cyan!~~!HoursPerDay,fuzzyTotalRemaining!~ remaining of the days worked~!Color,brightBlack!~.
+    * ~!Color,cyan!~~!HoursPerDay,fuzzyWeekTotalRemaining!~ remaining of the week~!Color,brightBlack!~.
+Goal: ~!DoneIt,hoursPerDay!~ hours per day, ~!DoneIt,daysPerWeek!~ days per week. ~!HoursPerDay,hoursPerWeek!~ hours per week.~!Color,default!~

--- a/packages-available/50-Did/hoursPerWeek.achel
+++ b/packages-available/50-Did/hoursPerWeek.achel
@@ -1,0 +1,6 @@
+# Use --hoursPerDay to display hours per week. ~ did,summary,hours,week
+#onDefine aliasFeature hoursPerWeek,hpw
+
+thisWeek
+requireContext
+hoursPerDay

--- a/packages-available/51-DoneIt/installDoneIt.achel
+++ b/packages-available/51-DoneIt/installDoneIt.achel
@@ -74,3 +74,7 @@ addTask l,-,Lunch,personal,silent
 addTask bp,-,Break (off the clock),personal,silent
 addTask ada,-,Awesomely dangerous activities - http://funnyhacks.com/tarp,personal,silent
 addTask zzz,-,Sleep,personal,silent
+
+# Set default hours per day.
+setIfNotSet DoneIt,hoursPerDay,8
+setIfNotSet DoneIt,daysPerWeek,5

--- a/packages-available/99-Convenience/default.achel
+++ b/packages-available/99-Convenience/default.achel
@@ -1,0 +1,3 @@
+# The thing to do in doneIt if no parameters are supplied. ~ default,doneit
+
+hoursPerWeek


### PR DESCRIPTION
Adds two new features:

```
Available features:
--hoursPerDay, --hpd
  For a list of dids (eg --today), list the number of hours worked each day. 

--hoursPerWeek, --hpw
  Use --hoursPerDay to display hours per week. 
```

And adds --default to display the `--hoursPerWeek` summary.